### PR TITLE
Refactor nickname handling in role sync and update command to support specific user updates

### DIFF
--- a/commands/administrator/updateNicknames.js
+++ b/commands/administrator/updateNicknames.js
@@ -4,7 +4,22 @@ module.exports = {
     permission: ["ADMINISTRATOR"],
     data: new SlashCommandBuilder()
         .setName('updatenicknames')
-        .setDescription('Update nicknames of all users in the server'),
+        .setDescription('Update nicknames of all users in the server')
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('all')
+                .setDescription('Update nicknames of all users in the server')
+        )
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('user')
+                .setDescription('Update nickname of a specific user')
+                .addUserOption(option =>
+                    option.setName('user')
+                        .setDescription('The user to update the nickname for')
+                        .setRequired(true)
+                )
+        ),
 
     /**
      *
@@ -21,24 +36,56 @@ module.exports = {
                         return { message: `ERROR - Failed to fetch WMKR Discord Server from Bot. Please verify correct Server ID in Settings file` }
                     })
 
-                let members = await guild.members.fetch()
-                let forumUsersToDiscord = await client.xenProvider.fetchAllDiscordLinkInfo()
-                for (const member of members.values()) {
-                    if (member.user.id !== member.guild.ownerId) {
-                        let user = forumUsersToDiscord.find(user => user.discord_user_id === member.user.id)
-                        if (user) {
-                            let user_username = await client.xenProvider.fetchUsername(user.user_id)
-                            let new_username = `[WMKR] ${user_username[0].username}`
-                            try {
-                                await member.setNickname(new_username)
-                            } catch (err) {
-                                client.logger.error(err.stack)
-                                return { message: "ERROR - Failed to set Nickname" }
+                if (!guild) {
+                    return { message: `ERROR - Failed to fetch WMKR Discord Server from Bot. Please verify correct Server ID in Settings file` }
+                }
+
+                if (interaction.options.getSubcommand() === 'user') {
+                    // Use the discordRoles.js controller to update the nickname of a specific user
+                    let user = interaction.options.getUser('user')
+                    let member = await guild.members.fetch(user.id)
+                        .catch(err => {
+                            client.logger.error(err.stack)
+                            return { message: `ERROR - Failed to fetch user from WMKR Discord Server` }
+                        })
+                    if (!member) {
+                        return { message: `ERROR - Failed to fetch user from WMKR Discord Server` }
+                    }
+                    let forumUsersToDiscord = await client.xenProvider.fetchAllDiscordLinkInfo()
+                    let userInfo = forumUsersToDiscord.find(user => user.discord_user_id === member.user.id)
+                    if (!userInfo) {
+                        return { message: `ERROR - Failed to fetch user from WMKR Discord Server` }
+                    }
+
+                    // Call the syncRole function to update the nickname
+                    await client.discordRolesController.syncRole(client, userInfo.user_id)
+                        .then(result => {
+                            interaction.followUp({ content: result.message, ephemeral: true })
+                        })
+
+                }
+
+                if (interaction.options.getSubcommand() === 'all') {
+
+                    let members = await guild.members.fetch()
+                    let forumUsersToDiscord = await client.xenProvider.fetchAllDiscordLinkInfo()
+                    for (const member of members.values()) {
+                        if (member.user.id !== member.guild.ownerId) {
+                            let user = forumUsersToDiscord.find(user => user.discord_user_id === member.user.id)
+                            if (user) {
+                                let user_username = await client.xenProvider.fetchUsername(user.user_id)
+                                let new_username = `[WMKR] ${user_username[0].username}`
+                                try {
+                                    await member.setNickname(new_username)
+                                } catch (err) {
+                                    client.logger.error(err.stack)
+                                    return { message: "ERROR - Failed to set Nickname" }
+                                }
                             }
                         }
                     }
+                    await interaction.followUp({ content: 'Nicknames updated', ephemeral: true })
                 }
-                await interaction.followUp({ content: 'Nicknames updated', ephemeral: true })
             })
     }
 }

--- a/controller/discordRoles.js
+++ b/controller/discordRoles.js
@@ -1,5 +1,5 @@
 class DiscordRolesController {
-    async syncRole(client, userId, forceNickname = 1) {
+    async syncRole(client, userId) {
         client.logger.info(`[FUNCTION] - SyncRole function used`);
         // Check if user has Linked Discord to account
         let user = await client.xenProvider.fetchDiscordLinkInfoForumUserId(userId)
@@ -36,6 +36,7 @@ class DiscordRolesController {
                 unsignedRole = guildRoles[3]
             client.logger.debug(bwcRole, guestRole, verifyRole, unsignedRole)
 
+            let message = ""
             if (!guildUser.roles.cache.has(bwcRole.firstKey())) {
                 client.logger.debug('Attempting to add WMKR Role')
                 await guildUser.roles.add(bwcRole)
@@ -62,34 +63,36 @@ class DiscordRolesController {
                         return { message: "ERROR - Failed to remove Unsigned Role" }
                     })
 
-                if (forceNickname === 1) {
-                    // Check if the user is the guild owner. We can't update the Nickname.
-                    if (guildUser.user.id !== guildUser.guild.ownerId) {
-                        // Check if user already has WMKR tags in their Nickname.
-                        if (!guildUser.roles.cache.has(bwcRole.firstKey()) && guildUser.nickname && guildUser.nickname.includes('[WMKR]')) {
-                            let new_username = guildUser.nickname.slice(6)
-                            await guildUser.setNickname(new_username)
-                                .catch(err => {
-                                    client.logger.error(err.stack)
-                                    return { message: "ERROR - Failed to set Nickname" }
-                                })
-                            // Check if user already has nickname and set and if it includes [WMKR]. If not, add them.
-                        } else if (guildUser.roles.cache.has(bwcRole.firstKey()) && !guildUser.nickname.includes('[WMKR]')) {
-                            // If not WMKR tags in name, add them.
-                            let user_username = await client.xenProvider.fetchUsername(user.user_id)
-                            let new_username = `[WMKR] ${user_username[0].username}`
-                            await guildUser.setNickname(new_username)
-                                .catch(err => {
-                                    client.logger.error(err.stack)
-                                    return { message: "ERROR - Failed to set Nickname" }
-                                })
-                        }
-                    } else {
-                        return { message: "ERROR - Cannot update nickname for guild owner" }
-                    }
-                }
+                message = "SUCCESS - Sync'd Discord Permissions\n"
+            } else {
+                message = "SUCCESS - Permissions are already synced\n"
             }
-            return { message: "SUCCESS - Sync'd Discord Permissions" }
+
+            // Check if the user is the guild owner. We can't update the Nickname.
+            if (guildUser.user.id !== guildUser.guild.ownerId) {
+                // Check if user already has WMKR tags in their Nickname.
+                if (!guildUser.roles.cache.has(bwcRole.firstKey()) && guildUser.nickname && guildUser.nickname.includes('[WMKR]')) {
+                    let new_username = guildUser.nickname.slice(6)
+                    await guildUser.setNickname(new_username)
+                        .catch(err => {
+                            client.logger.error(err.stack)
+                            return { message: "ERROR - Failed to set Nickname" }
+                        })
+                    // Check if user already has nickname and set and if it includes [WMKR]. If not, add them.
+                } else if (guildUser.roles.cache.has(bwcRole.firstKey()) && !guildUser.nickname.includes('[WMKR]')) {
+                    // If not WMKR tags in name, add them.
+                    let user_username = await client.xenProvider.fetchUsername(user.user_id)
+                    let new_username = `[WMKR] ${user_username[0].username}`
+                    await guildUser.setNickname(new_username)
+                        .catch(err => {
+                            client.logger.error(err.stack)
+                            return message += "ERROR - Failed to set Nickname"
+                        })
+                }
+            } else {
+                return message += "ERROR - Cannot update nickname for guild owner"
+            }
+            return { message: message }
         }
         return { message: "ERROR - Can't find members Discord ID in the Database" }
     }


### PR DESCRIPTION
This pull request enhances the functionality of the `updateNicknames` command to allow updating nicknames for individual users in addition to all users, and refactors the `syncRole` method to improve clarity and flexibility. Below are the most important changes grouped by theme:

### Enhancements to `updateNicknames` Command:
* Added subcommands `all` and `user` to the `updateNicknames` command. The `user` subcommand allows specifying a user whose nickname should be updated, while `all` retains the original functionality of updating all users' nicknames. (`commands/administrator/updateNicknames.js`, [commands/administrator/updateNicknames.jsL7-R22](diffhunk://#diff-6d020a54518184c285d59a813e268e3b1249cba0021f213dbde450d14be72b41L7-R22))
* Implemented logic to handle the `user` subcommand, including fetching the specified user, verifying their existence in the server, and syncing their nickname using the `syncRole` function. (`commands/administrator/updateNicknames.js`, [commands/administrator/updateNicknames.jsR39-R69](diffhunk://#diff-6d020a54518184c285d59a813e268e3b1249cba0021f213dbde450d14be72b41R39-R69))

### Refactoring of `syncRole` Method:
* Removed the `forceNickname` parameter from the `syncRole` method to simplify its usage. (`controller/discordRoles.js`, [controller/discordRoles.jsL2-R2](diffhunk://#diff-ddbb54b2b19c47ced7405fdf8a01d467f470378fbc83416547452b1581662640L2-R2))
* Introduced a `message` variable to accumulate success or error messages during the role synchronization process, improving clarity and enabling detailed feedback. (`controller/discordRoles.js`, [[1]](diffhunk://#diff-ddbb54b2b19c47ced7405fdf8a01d467f470378fbc83416547452b1581662640R39) [[2]](diffhunk://#diff-ddbb54b2b19c47ced7405fdf8a01d467f470378fbc83416547452b1581662640L65-R70)
* Updated error handling for nickname updates to append errors to the `message` variable instead of returning immediately, ensuring comprehensive feedback. (`controller/discordRoles.js`, [controller/discordRoles.jsL84-R95](diffhunk://#diff-ddbb54b2b19c47ced7405fdf8a01d467f470378fbc83416547452b1581662640L84-R95))